### PR TITLE
fix IMPORTS of schemas with STARTS

### DIFF
--- a/shex/src/main/java/fr/inria/lille/shexjava/schema/parsing/GenParser.java
+++ b/shex/src/main/java/fr/inria/lille/shexjava/schema/parsing/GenParser.java
@@ -78,7 +78,7 @@ public class GenParser {
 		
 		Set<Path> loaded = new HashSet<Path>();
 		Map<Label,ShapeExpr> allRules = new HashMap<Label,ShapeExpr>();
-		
+
 		List<Path> toload = new ArrayList<Path>();
 		toload.add(filepath);
 		
@@ -98,11 +98,16 @@ public class GenParser {
 			}else {
 				parser = new ShExRParser();
 			}
-			allRules.putAll(parser.getRules(rdfFactory,selectedPath));
+			Map<Label,ShapeExpr> newRules = parser.getRules(rdfFactory,selectedPath);
 			if (init) {
 				start = parser.getStart();
 				init = false;
+			} else {
+				// The start rule has a null key. We don't want IMPORTS
+				// to evict the start rule from the first schema.
+				newRules.remove(null);
 			}
+			allRules.putAll(newRules);
 			List<String> imports = parser.getImports();
 
 			for (String imp:imports) {


### PR DESCRIPTION
The ShapeExpr associated with a START= directive gets added to the
rules with a null hash key. Schemas which imported another schema
which had a START= lead to a hash conflict on null, causing all but
the last START ShapeExpr to have null IDs.

e.g. start2RefS1-IstartS2, start2RefS2-IstartS2

The rigth way to fix this may be to ensure that START= gets something
other than a null hash key, but you'd still have to prevent collisions.