### PR TITLE
don't rely on traits to default shapeLabel

### DIFF
--- a/shex/src/test/java/fr/inria/lille/shexjava/shexTest/AbstractValidationTest.java
+++ b/shex/src/test/java/fr/inria/lille/shexjava/shexTest/AbstractValidationTest.java
@@ -45,7 +45,7 @@ public abstract class AbstractValidationTest {
 		Graph dataGraph = getRDFGraph();    		
 		ValidationAlgorithmAbstract validation = getValidationAlgorithm(schema, dataGraph);   
 		
-		if (testCase.traits.contains(RDF_FACTORY.createIRI("http://www.w3.org/ns/shacl/test-suite#"+"Start")))
+		if (testCase.shapeLabel == null)
 			testCase.shapeLabel = schema.getStart().getId();
 			
 		validation.validate(testCase.focusNode, testCase.shapeLabel);


### PR DESCRIPTION
The old code looked for a <#Start> trait, which isn't reliable. New
code uses START= if no shapeLabel is supplied.

TODO: don't expect a testCase but instead some structure defined in an
API (which could look like a testCase, but a manifest API would
probably be nicer.